### PR TITLE
[Feat] Add cors origin

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,10 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins ['http://localhost:3000', 'http://localhost:3001'] # Add your frontend origin(s)
+
+    resource '/api/*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true
+  end
+end


### PR DESCRIPTION

### What: 
Added CORS origin configuration to allow cross-origin requests.

### Why: 
To enable frontend applications to interact with the API without restrictions.

### How: 
Configured rack-cors in config/initializers/cors.rb to allow specific origins and HTTP methods.